### PR TITLE
add tags list to landing page

### DIFF
--- a/src/features/layout/home/home.module.scss
+++ b/src/features/layout/home/home.module.scss
@@ -127,8 +127,15 @@
           flex-direction: column;
           justify-content: center;
           align-items: center;
+          gap: 40px;
           width: 100%;
           height: 80%;
+
+          .tagListContainer {
+            font-size: 1rem;
+            display: flex;
+            gap: 0.75rem;
+          }
         }
       }
     }

--- a/src/features/layout/home/pagePortal.tsx
+++ b/src/features/layout/home/pagePortal.tsx
@@ -52,13 +52,23 @@ export default function PagePortal({
       {isHovered && (
         <div className={styles.portalContent}>
           <AutoplayCarousel orientation="horizontal" content={content} />
+          <div className={styles.tagListContainer}>
+            {tags.map((tag, i) => (
+              <>
+                <p
+                  key={tag}>{tag} </p>
+                {i !== tags.length - 1 &&
+                  <p> | </p>
+                }
+              </>
+            ))}
+          </div>
           <Link href={`/${title}`}>
             <Button variant={buttonVariant}>Enter</Button>
           </Link>
+          <p style={{display: "none"}}>{color}</p>
         </div>
       )}
-      {tags}
-      {color}
     </div>
   );
 }


### PR DESCRIPTION
Mapped over the tags prop from the page portal and spaced things out nicely in the portal content