### PR TITLE
Fix hidden overflow in storybook

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,0 +1,6 @@
+<style>
+    html,
+    body {
+        overflow-y: auto;
+    }
+</style>


### PR DESCRIPTION
Fix the hidden overflow in storybook by adding a preview-body.html file to the storybook directory. Issue was caused by setting the html and body tags in the global styles to hidden so that there is no scroll on the landing page.