### PR TITLE
Fix hooks call in accordion and pagePortal files

### DIFF
--- a/src/features/layout/accordion/accordion.tsx
+++ b/src/features/layout/accordion/accordion.tsx
@@ -19,6 +19,11 @@ type AccordionPropsObj = {
 
 export function Accordion({ content, color }: AccordionProps) {
   const [active, setActive] = useState<string>("-1");
+
+  function hoverHandler(id: string) {
+    setActive(id);
+  }
+
   return (
     <div id="services" className={styles.accordion}>
       <p className={styles.title}>WHAT WE DO | SERVICES</p>
@@ -27,8 +32,8 @@ export function Accordion({ content, color }: AccordionProps) {
           <div
             className={styles.accordionSection}
             key={item.id}
-            onMouseOver={() => setActive(item.id)}
-            onMouseLeave={() => setActive("-1")}
+            onMouseOver={() => hoverHandler(item.id)}
+            onMouseLeave={() => hoverHandler("-1")}
             style={{
               backgroundColor: active === item.id ? `var(${color})` : "#000",
             }}

--- a/src/features/layout/home/pagePortal.tsx
+++ b/src/features/layout/home/pagePortal.tsx
@@ -25,10 +25,15 @@ export default function PagePortal({
   buttonVariant,
 }: PagePortalProps) {
   const [isHovered, setIsHovered] = useState(false);
+
+  function hoverHandler(isTrue: boolean) {
+    setIsHovered(isTrue);
+  }
+
   return (
     <div
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onMouseEnter={() => hoverHandler(true)}
+      onMouseLeave={() => hoverHandler(false)}
       className={styles.pagePortalContainer}
     >
       <AnimatePresence>


### PR DESCRIPTION
### Fix the placement of where the hooks are being called in both the accordion and page portal files.

From the React Docs:

> "Don’t call Hooks inside loops, conditions, nested functions, or try/catch/finally blocks. Instead, always use Hooks at the top level of your React function, before any early returns. You can only call Hooks while React is rendering a function component:"

- ✅  Call them at the top level in the body of a [function component](https://react.dev/learn/your-first-component).
- ✅  Call them at the top level in the body of a [custom Hook](https://react.dev/learn/reusing-logic-with-custom-hooks).

### References:

- [https://react.dev/reference/rules/rules-of-hooks#only-call-hooks-at-the-top-level](url)
- [https://stackoverflow.com/questions/67032648/how-to-use-hooks-inside-a-conditional-statement](url)