### PR TITLE
Fix the initial starting point of the animation in the bts section

### DIFF
--- a/src/features/layout/bts/bts.tsx
+++ b/src/features/layout/bts/bts.tsx
@@ -18,13 +18,12 @@ export function BTS({ content, page }: BTSProps) {
   useEffect(() => {
     setTimeout(() => {
       setActiveImage(activeImage === content.length - 1 ? 0 : activeImage + 1);
-      console.log(activeImage);
     }, 3000);
   }, [activeImage, content]);
 
   const animationVariant = {
     initial: {
-      x: -1000,
+      x: -400,
     },
     animate: {
       x: 0,


### PR DESCRIPTION
Made the initial variant on the x axis in the bts animation start at  -400px instead of -1000px